### PR TITLE
Added re-encodeable asserts_with_user_comments property to results

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -41,6 +41,13 @@ parse the output:
 ```
 $ node test.js | node parse.js
 { ok: true,
+  asserts_with_user_comments:
+   [ 'beep',
+     { ok: true, number: 1, name: 'should be equal' },
+     { ok: true, number: 2, name: 'should be equivalent' },
+     'boop',
+     { ok: true, number: 3, name: 'should be equal' },
+     { ok: true, number: 4, name: '(unnamed assert)' } ],
   asserts: 
    [ { ok: true, number: 1, name: 'should be equal' },
      { ok: true, number: 2, name: 'should be equivalent' },
@@ -129,6 +136,7 @@ If the test is [completely skipped](http://podwiki.hexten.net/TAP/TAP.html?page=
 
 ```
 { ok: true,
+  asserts_with_user_comments: [],
   asserts: [],
   pass: [],
   fail: [],
@@ -157,8 +165,17 @@ With [npm](https://npmjs.org) do:
 npm install tap-parser
 ```
 
+# usage
+
 You can use [browserify](http://browserify.org) to `require('tap-parser')` in
 the browser.
+
+You can use [node-tap](https://github.com/isaacs/node-tap) to re-encode the 
+parsed results to get the unparsed TAP results again:
+
+```
+var tapResults = require('tap').Producer.encode(results.asserts_with_user_comments);
+```
 
 # license
 

--- a/test/ok.js
+++ b/test/ok.js
@@ -1,5 +1,6 @@
 var test = require('tape');
 var parser = require('../');
+var TapProducer = require('tap').Producer;
 
 var lines = [
     'TAP version 13',
@@ -43,7 +44,7 @@ expected.asserts.push({
 });
 
 test('simple ok', function (t) {
-    t.plan(4 * 2 + 1 + 4 + 5);
+    t.plan(5 * 2 + 1 + 4 + 5);
     
     var p = parser(onresults);
     p.on('results', onresults);
@@ -72,5 +73,7 @@ test('simple ok', function (t) {
         t.same(results.errors, []);
         t.same(asserts.length, 4);
         t.same(results.asserts, asserts);
+        var tapResults = TapProducer.encode(results.asserts_with_user_comments);
+        t.same(tapResults, lines.join('\n') + '\n');
     }
 });


### PR DESCRIPTION
For those use cases where you want to preserve the test comments interleaved with the asserts. This property is re-encodeable with isaac's node-tap module to produce TAP output again from parsed TAP output.

This closes https://github.com/substack/tap-parser/issues/14
